### PR TITLE
Add option to Shell.ask to not lowercase answers

### DIFF
--- a/lib/loki/shell.ex
+++ b/lib/loki/shell.ex
@@ -222,6 +222,7 @@ defmodule Loki.Shell do
   @spec format(String.t) :: String.t
   defp format(input, opts \\ [])
   defp format(input, [sensitive: true]), do: String.replace(input, "\n", "")
-  defp format(input, _opts), do: String.replace(input, "\n", "") |> String.downcase
+  defp format(input, _opts) do
+    String.downcase(String.replace(input, "\n", ""))
+  end
 end
-

--- a/lib/loki/shell.ex
+++ b/lib/loki/shell.ex
@@ -17,13 +17,14 @@ defmodule Loki.Shell do
   Ask user input with given message. Returns tuple with parsed options.
   """
   @spec ask(String.t) :: {List.t, List.t, List.t}
-  def ask(message) when is_input(message) do
-    args = format(IO.gets message)
+  def ask(message, opts \\ [])
+  def ask(message, opts) when is_input(message) do
+    args = format(IO.gets(message), opts)
     OptionParser.parse([args])
   end
 
-  @spec ask(any) :: none()
-  def ask(_any), do: raise ArgumentError, message: "Invalid argument, accept String or List!"
+  @spec ask(any, any) :: none()
+  def ask(_message, _ops), do: raise ArgumentError, message: "Invalid argument, accept String or List!"
 
 
   @doc """
@@ -219,6 +220,8 @@ defmodule Loki.Shell do
 
 
   @spec format(String.t) :: String.t
-  defp format(input), do: String.replace(input, "\n", "") |> String.downcase
+  defp format(input, opts \\ [])
+  defp format(input, [sensitive: true]), do: String.replace(input, "\n", "")
+  defp format(input, _opts), do: String.replace(input, "\n", "") |> String.downcase
 end
 

--- a/test/loki/shell_test.exs
+++ b/test/loki/shell_test.exs
@@ -15,6 +15,15 @@ defmodule Loki.ShellTest do
       assert_received {[], ["answer"], []}
     end
 
+    test "#ask sensitive input" do
+      assert capture_io("AnSwEr", fn ->
+        awnser = ask("Test question?", sensitive: true)
+        send self(), awnser
+      end) == "Test question?"
+
+      assert_received {[], ["AnSwEr"], []}
+    end
+
     test "#yes? yes input" do
       assert capture_io("yes", fn ->
         awnser = yes?("Test question?")

--- a/test/loki/shell_test.exs
+++ b/test/loki/shell_test.exs
@@ -8,25 +8,47 @@ defmodule Loki.ShellTest do
   describe "Shell" do
     test "#ask input" do
       assert capture_io("answer", fn ->
-        ask("Test question?")
-        send self(), "answer"
+        awnser = ask("Test question?")
+        send self(), awnser
       end) == "Test question?"
 
-      assert_received "answer"
+      assert_received {[], ["answer"], []}
     end
 
-    test "#yes? input" do
+    test "#yes? yes input" do
       assert capture_io("yes", fn ->
-        yes?("Test question?")
-        send self(), "yes"
+        awnser = yes?("Test question?")
+        send self(), awnser
       end) == "Test question?"
+
+      assert_received true
     end
 
-    test "#no? input" do
-      assert capture_io("no", fn ->
-        yes?("Test question?")
-        send self(), "no"
+    test "#yes? y input" do
+      assert capture_io("y", fn ->
+        awnser = yes?("Test question?")
+        send self(), awnser
       end) == "Test question?"
+
+      assert_received true
+    end
+
+    test "#no? no input" do
+      assert capture_io("no", fn ->
+        awnser = no?("Test question?")
+        send self(), awnser
+      end) == "Test question?"
+
+      assert_received true
+    end
+
+    test "#no? n input" do
+      assert capture_io("n", fn ->
+        awnser = no?("Test question?")
+        send self(), awnser
+      end) == "Test question?"
+
+      assert_received true
     end
 
     test "#say to shell" do


### PR DESCRIPTION
Hi,

This should fix #35.

Kept the current behaviour as default to be backwards compatible, but this PR introduces the option `sensitive: true` to ignore the `String.downcase` and make the answer case sensitive.

Also took the liberty of fixing some Unit Tests and adding a couple more.

Cheers