### PR TITLE
Fixed compilation error due to missing parameter in __using__

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ end
 
 ## Usage
 
-Import all or desired module to scope:
+Import all or desired modules to scope:
 
 ```elixir
 defmodule Project do
-  use Loki
+  use Loki # Import all modules
 
+  # Or import single mudules
   import Loki.Shell
   import Loki.Cmd
   import Loki.Directory
@@ -40,61 +41,66 @@ end
 ## Modules
 
 ### Loki.Shell
+
 Helpers for interaction with user and printing message to shell.
 
- - `ask/2` - Ask user input with given message. Returns tuple with parsed options.
- - `yes?/1` - Ask about positive user input with given message.
- - `no?/1` - Ask about negative user input with given message.
- - `say/1` - Printing message to shell.
- - `say_create/1` - Printing message about create file to shell.
- - `say_force/1` -  Printing message about force action to shell.
- - `say_identical/1` - Printing message about identical files content to shell.
- - `say_skip/1` - Printing message about skipping action to shell.
- - `say_error/1` - Printing message about to shell.
- - `say_conflict/1` - Printing message about conflict to shell.
- - `say_exists/1` - Printing message about existance to shell.
- - `say_rename/2` - Printing message about rename files to shell.
- - `say_copy/2` - Printing message about copy files to shell.
- - `say_remove/1` - Printing message about removing file to shell.
+- `ask/2` - Ask user input with given message. Returns tuple with parsed options.
+- `yes?/1` - Ask about positive user input with given message.
+- `no?/1` - Ask about negative user input with given message.
+- `say/1` - Printing message to shell.
+- `say_create/1` - Printing message about create file to shell.
+- `say_force/1` -  Printing message about force action to shell.
+- `say_identical/1` - Printing message about identical files content to shell.
+- `say_skip/1` - Printing message about skipping action to shell.
+- `say_error/1` - Printing message about to shell.
+- `say_conflict/1` - Printing message about conflict to shell.
+- `say_exists/1` - Printing message about existance to shell.
+- `say_rename/2` - Printing message about rename files to shell.
+- `say_copy/2` - Printing message about copy files to shell.
+- `say_remove/1` - Printing message about removing file to shell.
 
 ### Loki.Cmd
+
 Executing terminal commands helpers.
 
-  - `execute/1` - Execute shell command with Env variables as options.
-  - `execute_in_path/2` - Execute shell command with Env variables as options in given path.
-  - `format_output/1` - Format execution output for reading in shell.
+- `execute/1` - Execute shell command with Env variables as options.
+- `execute_in_path/2` - Execute shell command with Env variables as options in given path.
+- `format_output/1` - Format execution output for reading in shell.
 
 ### Loki.Directory
+
 Working with folders helpers.
 
-  - `create_directory/1` - Helper for create directory.
-  - `exists_directory?/1` - Helper for checking if file exists.
-  - `copy_directory/2` - Helper for copy directory.
-  - `remove_directory/1` - Helper for remove directory.
+- `create_directory/1` - Helper for create directory.
+- `exists_directory?/1` - Helper for checking if file exists.
+- `copy_directory/2` - Helper for copy directory.
+- `remove_directory/1` - Helper for remove directory.
 
 ### Loki.File
+
 Helpers for working with file.
 
-  - `create_file/1` - Helper for create file.
-  - `create_file_force/1` - Helper for create file in force mode.
-  - `exists_file?/1` - Helper check if file exists.
-  - `identical_file?/2` - Helper check if file identical.
-  - `copy_file/2` - Helper for copy files.
-  - `create_link/2` - Helper for create link.
-  - `remove_file/1` - Helper for remove file.
-  - `rename/2` - Helper for rename files and dirs.
+- `create_file/1` - Helper for create file.
+- `create_file_force/1` - Helper for create file in force mode.
+- `exists_file?/1` - Helper check if file exists.
+- `identical_file?/2` - Helper check if file identical.
+- `copy_file/2` - Helper for copy files.
+- `create_link/2` - Helper for create link.
+- `remove_file/1` - Helper for remove file.
+- `rename/2` - Helper for rename files and dirs.
 
 ### Loki.FileManipulation
+
 Helpers for content manipulation injecting, appending, and other.
 
-   - `append_to_file/2` - Helper appends lines to file.
-   - `prepend_to_file/2` - Helper prepends lines to file.
-   - `remove_from_file/2` - Helper removes lines from file.
-   - `inject_into_file/3` - Helper injecting lines to file with `before` and `after` options.
-   - `replace_in_file/3` - Helper replaces lines in file.
-   - `comment_in_file/2` - Helper comments line in file.
-   - `uncomment_in_file/2` - Helper uncomments lines in file.
-   - `remove_comments_in_file` - Helper removes all comments in file.
+- `append_to_file/2` - Helper appends lines to file.
+- `prepend_to_file/2` - Helper prepends lines to file.
+- `remove_from_file/2` - Helper removes lines from file.
+- `inject_into_file/3` - Helper injecting lines to file with `before` and `after` options.
+- `replace_in_file/3` - Helper replaces lines in file.
+- `comment_in_file/2` - Helper comments line in file.
+- `uncomment_in_file/2` - Helper uncomments lines in file.
+- `remove_comments_in_file` - Helper removes all comments in file.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ end
 
 ## Usage
 
-Import all or desired modules to scope:
+Import all or desired module to scope:
 
 ```elixir
 defmodule Project do
-  use Loki # Import all modules
+  # Import all modules
+  use Loki
 
-  # Or import single mudules
+  # Or import single modules
   import Loki.Shell
   import Loki.Cmd
   import Loki.Directory
@@ -41,66 +42,61 @@ end
 ## Modules
 
 ### Loki.Shell
-
 Helpers for interaction with user and printing message to shell.
 
-- `ask/2` - Ask user input with given message. Returns tuple with parsed options.
-- `yes?/1` - Ask about positive user input with given message.
-- `no?/1` - Ask about negative user input with given message.
-- `say/1` - Printing message to shell.
-- `say_create/1` - Printing message about create file to shell.
-- `say_force/1` -  Printing message about force action to shell.
-- `say_identical/1` - Printing message about identical files content to shell.
-- `say_skip/1` - Printing message about skipping action to shell.
-- `say_error/1` - Printing message about to shell.
-- `say_conflict/1` - Printing message about conflict to shell.
-- `say_exists/1` - Printing message about existance to shell.
-- `say_rename/2` - Printing message about rename files to shell.
-- `say_copy/2` - Printing message about copy files to shell.
-- `say_remove/1` - Printing message about removing file to shell.
+  - `ask/2` - Ask user input with given message. Returns tuple with parsed options.
+  - `yes?/1` - Ask about positive user input with given message.
+  - `no?/1` - Ask about negative user input with given message.
+  - `say/1` - Printing message to shell.
+  - `say_create/1` - Printing message about create file to shell.
+  - `say_force/1` -  Printing message about force action to shell.
+  - `say_identical/1` - Printing message about identical files content to shell.
+  - `say_skip/1` - Printing message about skipping action to shell.
+  - `say_error/1` - Printing message about to shell.
+  - `say_conflict/1` - Printing message about conflict to shell.
+  - `say_exists/1` - Printing message about existance to shell.
+  - `say_rename/2` - Printing message about rename files to shell.
+  - `say_copy/2` - Printing message about copy files to shell.
+  - `say_remove/1` - Printing message about removing file to shell.
 
 ### Loki.Cmd
-
 Executing terminal commands helpers.
 
-- `execute/1` - Execute shell command with Env variables as options.
-- `execute_in_path/2` - Execute shell command with Env variables as options in given path.
-- `format_output/1` - Format execution output for reading in shell.
+  - `execute/1` - Execute shell command with Env variables as options.
+  - `execute_in_path/2` - Execute shell command with Env variables as options in given path.
+  - `format_output/1` - Format execution output for reading in shell.
 
 ### Loki.Directory
-
 Working with folders helpers.
 
-- `create_directory/1` - Helper for create directory.
-- `exists_directory?/1` - Helper for checking if file exists.
-- `copy_directory/2` - Helper for copy directory.
-- `remove_directory/1` - Helper for remove directory.
+  - `create_directory/1` - Helper for create directory.
+  - `exists_directory?/1` - Helper for checking if file exists.
+  - `copy_directory/2` - Helper for copy directory.
+  - `remove_directory/1` - Helper for remove directory.
 
 ### Loki.File
-
 Helpers for working with file.
 
-- `create_file/1` - Helper for create file.
-- `create_file_force/1` - Helper for create file in force mode.
-- `exists_file?/1` - Helper check if file exists.
-- `identical_file?/2` - Helper check if file identical.
-- `copy_file/2` - Helper for copy files.
-- `create_link/2` - Helper for create link.
-- `remove_file/1` - Helper for remove file.
-- `rename/2` - Helper for rename files and dirs.
+  - `create_file/1` - Helper for create file.
+  - `create_file_force/1` - Helper for create file in force mode.
+  - `exists_file?/1` - Helper check if file exists.
+  - `identical_file?/2` - Helper check if file identical.
+  - `copy_file/2` - Helper for copy files.
+  - `create_link/2` - Helper for create link.
+  - `remove_file/1` - Helper for remove file.
+  - `rename/2` - Helper for rename files and dirs.
 
 ### Loki.FileManipulation
-
 Helpers for content manipulation injecting, appending, and other.
 
-- `append_to_file/2` - Helper appends lines to file.
-- `prepend_to_file/2` - Helper prepends lines to file.
-- `remove_from_file/2` - Helper removes lines from file.
-- `inject_into_file/3` - Helper injecting lines to file with `before` and `after` options.
-- `replace_in_file/3` - Helper replaces lines in file.
-- `comment_in_file/2` - Helper comments line in file.
-- `uncomment_in_file/2` - Helper uncomments lines in file.
-- `remove_comments_in_file` - Helper removes all comments in file.
+  - `append_to_file/2` - Helper appends lines to file.
+  - `prepend_to_file/2` - Helper prepends lines to file.
+  - `remove_from_file/2` - Helper removes lines from file.
+  - `inject_into_file/3` - Helper injecting lines to file with `before` and `after` options.
+  - `replace_in_file/3` - Helper replaces lines in file.
+  - `comment_in_file/2` - Helper comments line in file.
+  - `uncomment_in_file/2` - Helper uncomments lines in file.
+  - `remove_comments_in_file` - Helper removes all comments in file.
 
 ## Documentation
 

--- a/lib/loki.ex
+++ b/lib/loki.ex
@@ -17,7 +17,7 @@ defmodule Loki do
   """
 
   @doc """
-  Imports all aveliable modules
+  Imports all availiable modules
   """
   defmacro __using__(_) do
     quote do

--- a/lib/loki.ex
+++ b/lib/loki.ex
@@ -1,5 +1,4 @@
 defmodule Loki do
-
   @moduledoc """
   Loki provide additional helpers for building command line application without running additional process.
 
@@ -17,11 +16,10 @@ defmodule Loki do
 
   """
 
-
   @doc """
   Imports all aveliable modules
   """
-  defmacro __using__() do
+  defmacro __using__(_) do
     quote do
       import Loki.Shell
       import Loki.Cmd


### PR DESCRIPTION
Hello.
After adding the library to my project it couldn't compile in the `use Loki` part. 
This is because the `use` requires the macro `__using__/1` to be declared and not `__using__/0`.
I just added an unused parameter `_` to the macro for it to compile correctly.
